### PR TITLE
Add support for trackpad (no middle click)

### DIFF
--- a/src/components/EditorViewport/hooks/usePanning.ts
+++ b/src/components/EditorViewport/hooks/usePanning.ts
@@ -20,10 +20,11 @@ function usePanning(canPan: boolean, viewport: any): null {
       e.stopPropagation();
       dispatch(startPanning(e.pageX, e.pageY));
     }
-
-    // pan on middle mouse button down and move
+    
+    // pan on mouse move when CTRL or middle mouse button is pressed and mouse is moved
     function onPointerMove(e: MouseEvent) {
-      if (!isPanning) return;
+      if (!isPanning && !e.ctrlKey) return;
+      if (!isPanning && e.ctrlKey) dispatch(startPanning(e.pageX, e.pageY));
       e.preventDefault();
       e.stopPropagation();
       dispatch(setViewportPos(e.pageX, e.pageY));
@@ -38,14 +39,26 @@ function usePanning(canPan: boolean, viewport: any): null {
       dispatch(stopPanning());
     }
 
+    // end pan on ctrlKey up
+    function onKeyUp(e: KeyboardEvent) {
+      console.log(e)
+      if(!isPanning) return;
+      if(e.key != "Control") return;
+      e.preventDefault();
+      e.stopPropagation();
+      dispatch(stopPanning());
+    }
+    
     viewport.addEventListener("pointerdown", onPointerDown);
     viewport.addEventListener("pointerup", onPointerUp);
     viewport.addEventListener("pointermove", onPointerMove);
+    viewport.addEventListener("keyup", onKeyUp);
 
     return () => {
       viewport.removeEventListener("pointerdown", onPointerDown);
       viewport.removeEventListener("pointerup", onPointerUp);
       viewport.removeEventListener("pointermove", onPointerMove);
+      viewport.removeEventListener("keyup", onKeyUp);
     };
 
   }, [canPan, viewport, isPanning]);


### PR DESCRIPTION
Pan with CTRL key down (support for trackpad / mouse without middle click). Due to a bug in Storybook, this doesn't work well in the doc. To test it in storybook you need to first focus on a INPUT (i.e. a number box in Playground/Stress Test) or the KeyUp won't be registered.

CTRL is arbitrary and could be replace by something else.

A better workflow for trackpad would be to use the pinch gesture for zoom in/out and scroll for panning.